### PR TITLE
Add numpy required by titus

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.4
+current_version = 2.4.5
 commit = True
 tag = True
 tag_name = {new_version}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ COPY docker/run.sh /
 RUN adduser -H -D -u 1000 woken \
     && apk add --update --no-cache curl
 
-RUN apk add --update --no-cache python2 py2-pip \
-    && pip2 install titus
+RUN apk add --update --no-cache python2 python2-dev gfortran build-base py2-pip \
+    && pip2 install numpy titus
 
 COPY src/main/python/pfa_eval.py /pfa_eval.py
 COPY --from=scala-build-env /build/target/scala-2.11/woken-validation-all.jar /opt/woken-validation/woken-validation.jar

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It embeds [Apache Spark](http://spark.apache.org/) which provides the numerical 
 
 ```sh
 
- docker run --rm --env [list of environment variables] --link woken hbpmip/woken-validation:2.4.4
+ docker run --rm --env [list of environment variables] --link woken hbpmip/woken-validation:2.4.5
 
 ```
 

--- a/src/main/python/pfa_eval.py
+++ b/src/main/python/pfa_eval.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python2
 
-import logging
 import argparse
 import json
 import sys
@@ -10,10 +9,18 @@ from titus.genpy import PFAEngine
 from titus.datatype import AvroRecord, AvroString
 from titus.errors import *
 
+import logging
+from logging import FileHandler, StreamHandler
+
+log = logging.getLogger('')
+log.addHandler(StreamHandler(sys.stdout))
+log.addHandler(FileHandler('/tmp/pfa_eval.log'))
+
+
 def load_document(file):
     # Check that the file passed by the user exists
     if not os.path.exists(file):
-        print_error("The path you provided does not exist:" + os.path.abspath(file))
+        log.error("The path you provided does not exist:" + os.path.abspath(file))
         sys.exit(1)
 
     with open(file, 'r') as content_file:
@@ -31,43 +38,44 @@ def get_engine(json_string):
 
     except ValueError as ex:
         # JSON validation
-        logging.error("The file provided does not contain a valid JSON document: " + str(ex))
+        log.error("The file provided does not contain a valid JSON document: " + str(ex))
         sys.exit(1)
     except PFASyntaxException as ex:
         # Syntax validation
-        logging.error("The file provided does not contain a valid PFA compliant document: " + str(ex))
+        log.error("The file provided does not contain a valid PFA compliant document: " + str(ex))
         sys.exit(1)
     except PFASemanticException as ex:
         # PFA semantic check
-        logging.error("The file provided contains inconsistent PFA semantics: " + str(ex))
+        log.error("The file provided contains inconsistent PFA semantics: " + str(ex))
         sys.exit(1)
     except PFAInitializationException as ex:
         # Scoring engine check
-        logging.error("It wasn't possible to build a valid scoring engine from the PFA document: " + str(ex))
+        log.error("It wasn't possible to build a valid scoring engine from the PFA document: " + str(ex))
         sys.exit(1)
     except Exception as ex:
         # Other exceptions
-        logging.error("An unknown exception occurred: " + str(ex))
+        log.error("An unknown exception occurred: " + str(ex))
         sys.exit(1)
 
     # Check that the PFA file uses the "map" method. Other methods are not supported
     # (because irrelevant) by the MIP
     if not engine.config.method == "map":
-        logging.error("The PFA method you used is not supported. Please use the PFA 'map' method")
+        log.error("The PFA method you used is not supported. Please use the PFA 'map' method")
         sys.exit(1)
 
     # Check that the PFA file uses a "record" type as input
     if not isinstance(engine.config.input, AvroRecord):
-        logging.error("The PFA document must take a record as input parameter. " \
+        log.error("The PFA document must take a record as input parameter. " \
                       "Each field of the record must describe a variable")
         sys.exit(1)
 
     # Check that the PFA file has a least one input field
     if not engine.config.input.fields:
-        logging.error("The PFA document must describe an input record with at least one field")
+        log.error("The PFA document must describe an input record with at least one field")
         sys.exit(1)
 
     return engine
+
 
 def main(pfa_file, data_file, results_file):
 
@@ -75,13 +83,13 @@ def main(pfa_file, data_file, results_file):
     data = json.loads(load_document(data_file))
     string_output = isinstance(engine.config.output, AvroString)
 
-    with open(results_file,"w") as results:
+    with open(results_file, "w") as results:
         results.write("[")
         first = True
         for item in data:
             prediction = engine.action(item)
             if first:
-              first = False
+                first = False
             else:
                 results.write(',')
             if string_output:
@@ -89,6 +97,7 @@ def main(pfa_file, data_file, results_file):
             else:
                 results.write("%s" % str(prediction))
         results.write("]")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Make predictions from data by evaluating a PFA model.')
@@ -98,4 +107,8 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    main(args.pfa_file, args.data_file, args.results_file)
+    try:
+        main(args.pfa_file, args.data_file, args.results_file)
+    except Exception as e:
+        log.exception(e)
+        sys.exit(1)


### PR DESCRIPTION
* add numpy required by titus
* log errors to file in addition to stdout / stderr since the scala does not capture output [here](https://github.com/LREN-CHUV/woken-validation/blob/master/src/main/scala/ch/chuv/lren/woken/validation/ValidationActor.scala#L119) (the reason might be trivial, but I couldn't figure it out)

(I pushed 2.4.5 to docker cloud, but didn't change the version anywhere else. Any help where to change that would be much appreciated)